### PR TITLE
Add support for escape sequences in string literals.

### DIFF
--- a/subx/003trace.test.cc
+++ b/subx/003trace.test.cc
@@ -64,6 +64,11 @@ void test_trace_count_ignores_trailing_whitespace() {
   CHECK_EQ(trace_count("test layer 1", "foo"), 1);
 }
 
+void test_trace_unescapes_newlines() {
+  trace("test layer 1") << "f\no\no\n" << end();
+  CHECK_TRACE_CONTENTS("test layer 1: f\\no\\no");
+}
+
 // pending: DUMP tests
 // pending: readable_contents() adds newline if necessary.
 // pending: raise also prints to stderr.

--- a/subx/038---literal_strings.cc
+++ b/subx/038---literal_strings.cc
@@ -77,11 +77,11 @@ void add_global_to_data_segment(const string& name, const word& value, segment& 
 
 void test_instruction_with_string_literal() {
   parse_instruction_character_by_character(
-      "a \"abc  def\" z\n"  // two spaces inside string
+      "a \"abc  def\\nwee\" z\n"  // two spaces inside string
   );
   CHECK_TRACE_CONTENTS(
       "parse2: word: a\n"
-      "parse2: word: \"abc  def\"\n"
+      "parse2: word: \"abc  def\\nwee\"\n"
       "parse2: word: z\n"
   );
   // no other words
@@ -123,7 +123,18 @@ void parse_instruction_character_by_character(const string& line_data, vector<li
       d << c;
       while (has_data(in)) {
         in >> c;
-        d << c;
+        if(c == '\\') {
+          in >> c;
+          if(c == 'n') d << '\n';
+          else if(c == 't') d << '\t';
+          else if(c == '"') d << '"';
+          else {
+            raise << "parse_instruction_character_by_character: unknown escape sequence '\\" << c << "'\n" << end();
+            return;
+          }
+        } else {
+          d << c;
+        }
         if (c == '"') break;
       }
       result.words.back().data = d.str();

--- a/subx/Readme.md
+++ b/subx/Readme.md
@@ -651,11 +651,6 @@ from a slice:
 * `skip-chars-matching-in-slice`: curr, end, delimiter byte -> new-curr (in `EAX`)
 * `skip-chars-not-matching-in-slice`:  curr, end, delimiter byte -> new-curr (in `EAX`)
 
-## Known issues
-
-* String literals support no escape sequences. In particular, no way to
-  represent newlines.
-
 ## Resources
 
 * [Single-page cheatsheet for the x86 ISA](https://net.cs.uni-bonn.de/fileadmin/user_upload/plohmann/x86_opcode_structure_and_instruction_overview.pdf)


### PR DESCRIPTION
This layered approach seems like a superb way to build software. It made it super easy to grasp what's going on. Put this PR together in an hour an a half, having never looked at the subx code before. Really excited to see where this project goes :)

The patch adds supports for \n, \t and \" in string literals.

To avoid screwing up the trace format, I added the functionality to unescape newlines in the messages.  