### PR TITLE
halt until exception when waiting for keyboard

### DIFF
--- a/102keyboard.subx
+++ b/102keyboard.subx
@@ -24,6 +24,8 @@ read-key:  # kbd: (addr keyboard) -> result/eax: byte
     89/<- %ebp 4/r32/esp
     # . save registers
     51/push-ecx
+    # wait for an interrupt to save power on Qemu
+    f4/hlt
     # result = 0
     b8/copy-to-eax 0/imm32
     # ecx = keyboard


### PR DESCRIPTION
This fixes #53, reducing CPU consumption from 180% to 2% when running Qemu.

Many thanks to @copy for this suggestion.